### PR TITLE
Add a development environment to Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,3 @@ RUN gulp client:build
 RUN sh setup-kerberos.sh
 
 EXPOSE 4000
-
-CMD ["pm2-runtime", "start", "-i", "10", "dist/server.js"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+up-prod:
+	sudo docker-compose -f docker-compose.yml -f docker-compose-prod.yml up
+
+up-dev:
+	sudo docker-compose -f docker-compose.yml -f docker-compose-dev.yml up

--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ Besök sidan på http://localhost:4000/ . När du ändrar i koden laddar den om 
 
 
 ### Docker
-Du kan lätt få upp sidan genom att använda docker. Notera att sidan sätter sig i productionsläge direkt när du 
-kör docker.
+Du kan lätt få upp sidan genom att använda docker.
 
 Först behöver du klona repot, och skapa en config-fil, se till att ändra session-secret till något gött
 och bra långt!
@@ -55,7 +54,19 @@ Efter detta är det lätt att slänga igång sidan:
 ```bash
 $> docker-compose build
 ...
-$> docker-compose up -d
+```
+
+För att starta sidan i en produktionsmiljö, kör:
+
+```bash
+$> make up-prod
+...
+```
+
+För att starta den i en utvecklingsmiljö, kör:
+
+```bash
+$> make up-dev
 ...
 ```
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,5 @@
+version: '3'
+
+services:
+    dfotose:
+        command: "gulp"

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,0 +1,7 @@
+version: '3'
+
+services:
+    dfotose:
+        environment:
+          - NODE_ENV=production
+        command: ["pm2-runtime", "start", "-i", "10", "dist/server.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,7 @@ services:
     volumes:
       - ./storage:/dfotose/storage
       - ./uploaded-images:/dfotose/uploaded-images
-    environment:
-      - NODE_ENV=production
+      - ./src:/dfotose/src
     links:
       - mongo
       - redis
@@ -23,6 +22,4 @@ services:
       - MONGO_DATA_DIR=/data/db
     volumes:
       - ./data/db:/data/db
-    ports:
-      - 27017:27017
     command: mongod --smallfiles


### PR DESCRIPTION
Using the previous Docker setup, running the app in Docker meant that it would run in a production environment. This is not optimal when developing, since it requires rebuilding the container in order to see the changes that have been made. I have added the option of running the app in a development environment which, among other things, makes changes visible right away.

The way this is done is by creating two additional docker-compose files, which override the settings of the master docker-compose file.