### PR TITLE
Fix broken image upload progress bar

### DIFF
--- a/src/client/ImageStore.js
+++ b/src/client/ImageStore.js
@@ -9,7 +9,7 @@ export class Image {
   constructor(data) {
     this.data = data;
   }
-  
+
   @computed get id() {
     return this.data._id;
   }
@@ -29,7 +29,7 @@ export class Image {
   @computed get thumbnail() {
     return `/v1/image/${this.data._id}/thumbnail`;
   }
-  
+
   @computed get fullSize() {
     return `/v1/image/${this.data._id}/fullSize`;
   }
@@ -37,7 +37,7 @@ export class Image {
   @computed get preview() {
     return `/v1/image/${this.data._id}/preview`;
   }
-  
+
   @computed get tags() {
     return this.data.tags.toJS();
   }
@@ -53,15 +53,15 @@ export class Image {
   @action unmark() {
     this.marked = false;
   }
-  
+
   @action addTag(tagName) {
     const imageId = this.data._id;
-    
+
     const imageTag = {
       imageId: imageId,
       tagName: tagName
     };
-    
+
     return axios.post(`/v1/image/${imageId}/tags`, imageTag)
       .then((() => {
         this.data.tags.push(tagName);
@@ -72,7 +72,7 @@ export class Image {
 export class ImageGalleryList {
   @observable images = [];
   @observable galleryId = null;
-  
+
   constructor(galleryId, images) {
     this.galleryId = galleryId;
     this.images = images;
@@ -89,13 +89,13 @@ export class ImageGalleryList {
 
   @action addImages(formData, progressCallback) {
     const config = {
-      progress: (event => {
+      onUploadProgress: (event => {
         const decimalPercentage = event.loaded / event.total;
         const percent = Math.round(decimalPercentage * 10000) / 100;
         progressCallback(percent);
       })
     };
-    
+
     return axios.post(`/v1/image/${this.galleryId}`, formData, config)
       .then((() => {
         this.fetchImages();
@@ -123,7 +123,7 @@ export class ImageGalleryList {
 export class ImagesForTagList {
   @observable images = [];
   @observable tag = null;
-  
+
   constructor(tag) {
     this.tag = tag;
     this.fetchImages();


### PR DESCRIPTION
After clicking "upload" on an image, the upload form changes to a progress bar indicating the progress of the image upload. After the upload is finished, the form is supposed to return. There was a bug that caused this progress bar to freeze at 0%, giving the user no feedback regarding the progress, and also forcing them to refresh the page to regain the upload form. 

This pull request fixes this bug which was caused by an incorrectly named callback function