### PR TITLE
Speed up build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,13 @@ FROM node:10
 
 WORKDIR /dfotose
 
-# Bundle app source
-COPY . .
-
 # Install all dependencies
+COPY package.json .
 RUN npm install
 RUN npm install -g gulp pm2
+
+# Bundle app source
+COPY . .
 
 # Build the app
 RUN gulp server:build
@@ -16,5 +17,3 @@ RUN gulp client:copy
 RUN gulp client:build
 
 RUN sh setup-kerberos.sh
-
-EXPOSE 4000


### PR DESCRIPTION
By adding package.json and running `npm install` before adding the other files, Docker is able to cache all npm packages meaning it does not have to reinstall them every time we build. This speeds up the build significantly.