### PR TITLE
Retry database connection on failure

### DIFF
--- a/src/server/server.js
+++ b/src/server/server.js
@@ -19,7 +19,20 @@ import userRoleRouter from './routes/user-role-api';
 import config from './config';
 
 mongoose.promise = global.Promise;
-mongoose.connect(`mongodb://${config.database.host}:27017/${config.database.name}`, { useNewUrlParser: true });
+
+const connectWithRetry = () => {
+  console.log('MongoDB connection with retry')
+  mongoose.connect(`mongodb://${config.database.host}:27017/${config.database.name}`, { useNewUrlParser: true });
+}
+
+// Retry connection on failure
+mongoose.connection.on('error', err => {
+  console.log(`MongoDB connection error: ${err}`)
+  setTimeout(connectWithRetry, 5000)
+})
+
+connectWithRetry();
+
 
 const app = express();
 


### PR DESCRIPTION
When started in a Docker container, MongoDB will sometimes take a while to start, which results in node being unable to connect as the database is not yet ready to accept connections when it attempts to do so. To remedy this, we simply retry if an attempt at connecting fails. Ideally, we would like to have docker wait for mongoDB to start before launching the node application, but this is currently not possible since Docker considers the database to be ready as soon as its process is started, and not when it's actually ready to accept connections. Hence, this seems to be the best we can do at the moment.